### PR TITLE
Ability to disable sourceMap

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ module.exports = function(source) {
   }).then(function(modules) {
     var result = sweet.compile(source, {
       modules: modules,
-      sourceMap: true,
+      sourceMap: !(config.sourceMap === 'false'),
       filename: fileRequest
     });
 


### PR DESCRIPTION
I needed ability to disable source maps because I got weird errors that I just can't fix:

```
Hash: de4c95cbb57b5ff7f241
Version: webpack 1.3.1-beta3
Time: 8894ms
    Asset    Size  Chunks             Chunk Names
js/app.js  887876       0  [emitted]  app
chunk    {0} js/app.js (app) 858197 [rendered]
    [0] ./app/app.jsx 981 {0} [built] [6 errors]
    [1] ./app/stores/actions.js 1757 {0} [built]
    [3] ./app/stores/global_notifications_store.js 2286 {0} [built]
    [9] ./~/react/react.js 40 {0} [built]
   [10] ./~/script-loader!./~/sugar/release/sugar-full.development.js 440 {0} [built]
   [11] ./~/script-loader/addScript.js 223 {0} [built]
   [12] ./~/script-loader/~/raw-loader!./~/sweetjs-loader?sourceMap=false&modules[]=es6-macros,/Users/koss/src/app-front/config/macros.sjs,readers[]=jsx-reader!./~/sugar/release/sugar-full.development.js 299759 {0} [built]
   [13] ./app/components/shared/css/layout.styl 533 {0} [built]
   [14] ./~/css-loader!./~/autoprefixer-loader!./~/stylus-loader!./app/components/shared/css/layout.styl 541 {0} [built]
   [15] ./~/style-loader/addStyle.js 717 {0} [built]
   [16] ./app/lib/utils.js 374 {0} [built]
   [17] ./~/react/lib/React.js 3850 {0} [built]
   [18] ./~/react/lib/DOMPropertyOperations.js 6471 {0} [built]
   [19] ./~/react/lib/EventPluginUtils.js 7874 {0} [built]
   [20] ./~/react/lib/ReactChildren.js 4956 {0} [built]
   [21] ./~/react/lib/ReactComponent.js 17537 {0} [built]
   [22] ./~/react/lib/ReactCompositeComponent.js 48756 {0} [built]
   [23] ./~/react/lib/ReactContext.js 1446 {0} [built]
   [24] ./~/react/lib/ReactCurrentOwner.js 983 {0} [built]
   [25] ./~/react/lib/ReactDOM.js 5517 {0} [built]
   [26] ./~/react/lib/ReactDOMComponent.js 13221 {0} [built]
   [27] ./~/react/lib/ReactDefaultInjection.js 4992 {0} [built]
   [28] ./~/react/lib/ReactInstanceHandles.js 10159 {0} [built]
   [29] ./~/react/lib/ReactMount.js 19531 {0} [built]
   [30] ./~/react/lib/ReactMultiChild.js 12643 {0} [built]
   [31] ./~/react/lib/ReactPerf.js 2077 {0} [built]
   [32] ./~/react/lib/ReactPropTypes.js 11937 {0} [built]
   [33] ./~/react/lib/ReactServerRendering.js 3598 {0} [built]
   [34] ./~/react/lib/ReactTextComponent.js 3420 {0} [built]
   [35] ./~/react/lib/onlyChild.js 1585 {0} [built]
   [36] ./~/react/lib/ExecutionEnvironment.js 1302 {0} [built]
   [37] (webpack)/~/node-libs-browser/~/process/browser.js 1814 {0} [built]
   [38] ./~/react/lib/EventConstants.js 2154 {0} [built]
   [39] ./~/react/lib/invariant.js 2256 {0} [built]
   [40] ./~/react/lib/PooledClass.js 4261 {0} [built]
   [41] ./~/react/lib/traverseAllChildren.js 7190 {0} [built]
   [42] ./~/react/lib/DOMProperty.js 6796 {0} [built]
   [43] ./~/react/lib/escapeTextForBrowser.js 1270 {0} [built]
   [44] ./~/react/lib/memoizeStringOnly.js 1189 {0} [built]
   [45] ./~/react/lib/warning.js 1610 {0} [built]
   [46] ./~/react/lib/ReactOwner.js 4153 {0} [built]
   [47] ./~/react/lib/ReactUpdates.js 5422 {0} [built]
   [48] ./~/react/lib/keyMirror.js 1711 {0} [built]
   [49] ./~/react/lib/merge.js 1192 {0} [built]
   [50] ./~/react/lib/monitorCodeUse.js 1320 {0} [built]
   [51] ./~/react/lib/ReactErrorUtils.js 830 {0} [built]
   [52] ./~/react/lib/ReactPropTransferer.js 3607 {0} [built]
   [53] ./~/react/lib/ReactPropTypeLocations.js 878 {0} [built]
   [54] ./~/react/lib/ReactPropTypeLocationNames.js 936 {0} [built]
   [55] ./~/react/lib/instantiateReactComponent.js 2717 {0} [built]
   [56] ./~/react/lib/mixInto.js 1055 {0} [built]
   [57] ./~/react/lib/objMap.js 1472 {0} [built]
   [58] ./~/react/lib/shouldUpdateReactComponent.js 2284 {0} [built]
   [59] ./~/react/lib/mergeInto.js 1387 {0} [built]
   [60] ./~/react/lib/objMapKeyVal.js 1465 {0} [built]
   [61] ./~/react/lib/ReactInjection.js 1661 {0} [built]
   [62] ./~/react/lib/DefaultDOMPropertyConfig.js 7046 {0} [built]
   [63] ./~/react/lib/ChangeEventPlugin.js 13078 {0} [built]
   [64] ./~/react/lib/ClientReactRootIndex.js 889 {0} [built]
   [65] ./~/react/lib/CompositionEventPlugin.js 8737 {0} [built]
   [66] ./~/react/lib/DefaultEventPluginOrder.js 1772 {0} [built]
   [67] ./~/react/lib/EnterLeaveEventPlugin.js 4372 {0} [built]
   [68] ./~/react/lib/MobileSafariClickEventPlugin.js 1785 {0} [built]
   [69] ./~/react/lib/ReactBrowserComponentMixin.js 1143 {0} [built]
   [70] ./~/react/lib/ReactComponentBrowserEnvironment.js 4235 {0} [built]
   [71] ./~/react/lib/ReactEventTopLevelCallback.js 4565 {0} [built]
   [72] ./~/react/lib/ReactDOMButton.js 2247 {0} [built]
   [73] ./~/react/lib/ReactDOMForm.js 2226 {0} [built]
   [74] ./~/react/lib/ReactDOMImg.js 1989 {0} [built]
   [75] ./~/react/lib/ReactDOMInput.js 7410 {0} [built]
   [76] ./~/react/lib/ReactDOMOption.js 1789 {0} [built]
   [77] ./~/react/lib/ReactDOMSelect.js 6676 {0} [built]
   [78] ./~/react/lib/ReactDOMTextarea.js 5771 {0} [built]
   [79] ./~/react/lib/SelectEventPlugin.js 6696 {0} [built]
   [80] ./~/react/lib/ServerReactRootIndex.js 1206 {0} [built]
   [81] ./~/react/lib/SimpleEventPlugin.js 14705 {0} [built]
   [82] ./~/react/lib/ReactDefaultBatchingStrategy.js 2383 {0} [built]
   [83] ./~/react/lib/createFullPageComponent.js 2295 {0} [built]
   [84] ./~/react/lib/ReactDefaultPerf.js 10217 {0} [built]
   [85] ./~/react/lib/ReactEventEmitter.js 11943 {0} [built]
   [86] ./~/react/lib/containsNode.js 1673 {0} [built]
   [87] ./~/react/lib/getReactRootElementInContainer.js 1247 {0} [built]
   [88] ./~/react/lib/ReactRootIndex.js 1035 {0} [built]
   [89] ./~/react/lib/CSSPropertyOperations.js 3056 {0} [built]
   [90] ./~/react/lib/keyOf.js 1466 {0} [built]
   [91] ./~/react/lib/ReactMultiChildUpdateTypes.js 1176 {0} [built]
   [92] ./~/react/lib/flattenChildren.js 1992 {0} [built]
   [93] ./~/react/lib/ReactMarkupChecksum.js 1494 {0} [built]
   [94] ./~/react/lib/ReactServerRenderingTransaction.js 2985 {0} [built]
   [95] ./~/react/lib/createObjectFrom.js 1893 {0} [built]
   [96] ./~/react/lib/emptyObject.js 793 {0} [built]
   [97] ./~/react/lib/emptyFunction.js 1483 {0} [built]
   [98] ./~/react/lib/joinClasses.js 1305 {0} [built]
   [99] ./~/react/lib/mergeHelpers.js 3273 {0} [built]
  [100] ./~/react/lib/EventPluginHub.js 8532 {0} [built]
  [101] ./~/react/lib/EventPropagators.js 5468 {0} [built]
  [102] ./~/react/lib/SyntheticEvent.js 5233 {0} [built]
  [103] ./~/react/lib/isEventSupported.js 2289 {0} [built]
  [104] ./~/react/lib/isTextInputElement.js 1399 {0} [built]
  [105] ./~/react/lib/ReactInputSelection.js 4822 {0} [built]
  [106] ./~/react/lib/SyntheticCompositionEvent.js 1485 {0} [built]
  [107] ./~/react/lib/getTextContentAccessor.js 1343 {0} [built]
  [108] ./~/react/lib/SyntheticMouseEvent.js 2733 {0} [built]
  [109] ./~/react/lib/AutoFocusMixin.js 951 {0} [built]
  [110] ./~/react/lib/getEventTarget.js 1278 {0} [built]
  [111] ./~/react/lib/ReactDOMIDOperations.js 6371 {0} [built]
  [112] ./~/react/lib/ReactReconcileTransaction.js 4754 {0} [built]
  [113] ./~/react/lib/LinkedValueUtils.js 5333 {0} [built]
  [114] ./~/react/lib/getActiveElement.js 1144 {0} [built]
  [115] ./~/react/lib/shallowEqual.js 1552 {0} [built]
  [116] ./~/react/lib/Transaction.js 11354 {0} [built]
  [117] ./~/react/lib/SyntheticClipboardEvent.js 1594 {0} [built]
  [118] ./~/react/lib/SyntheticFocusEvent.js 1446 {0} [built]
  [119] ./~/react/lib/SyntheticKeyboardEvent.js 1780 {0} [built]
  [120] ./~/react/lib/SyntheticDragEvent.js 1450 {0} [built]
  [121] ./~/react/lib/SyntheticTouchEvent.js 1597 {0} [built]
  [122] ./~/react/lib/SyntheticUIEvent.js 1440 {0} [built]
  [123] ./~/react/lib/SyntheticWheelEvent.js 1893 {0} [built]
  [124] ./~/react/lib/ReactDefaultPerfAnalysis.js 7351 {0} [built]
  [125] ./~/react/lib/performanceNow.js 1288 {0} [built]
  [126] ./~/react/lib/isTextNode.js 945 {0} [built]
  [127] ./~/react/lib/EventListener.js 1809 {0} [built]
  [128] ./~/react/lib/EventPluginRegistry.js 8960 {0} [built]
  [129] ./~/react/lib/ReactEventEmitterMixin.js 1447 {0} [built]
  [130] ./~/react/lib/ViewportMetrics.js 1147 {0} [built]
  [131] ./~/react/lib/CSSProperty.js 3806 {0} [built]
  [132] ./~/react/lib/dangerousStyleValue.js 2222 {0} [built]
  [133] ./~/react/lib/hyphenate.js 1008 {0} [built]
  [134] ./~/react/lib/adler32.js 1298 {0} [built]
  [135] ./~/react/lib/ReactMountReady.js 2187 {0} [built]
  [136] ./~/react/lib/ReactPutListenerQueue.js 1742 {0} [built]
  [137] ./~/react/lib/copyProperties.js 1952 {0} [built]
  [138] ./~/react/lib/accumulate.js 1859 {0} [built]
  [139] ./~/react/lib/forEachAccumulated.js 1263 {0} [built]
  [140] ./~/react/lib/ReactDOMSelection.js 6420 {0} [built]
  [141] ./~/react/lib/focusNode.js 940 {0} [built]
  [142] ./~/react/lib/DOMChildrenOperations.js 5916 {0} [built]
  [143] ./~/react/lib/getEventKey.js 2602 {0} [built]
  [144] ./~/react/lib/isNode.js 1035 {0} [built]
  [145] ./~/react/lib/getUnboundedScrollPosition.js 1452 {0} [built]
  [146] ./~/react/lib/getNodeForCharacterOffset.js 2265 {0} [built]
  [147] ./~/react/lib/Danger.js 7485 {0} [built]
  [148] ./~/react/lib/createNodesFromMarkup.js 3300 {0} [built]
  [149] ./~/react/lib/getMarkupWrap.js 4152 {0} [built]
  [150] ./~/react/lib/createArrayFrom.js 2381 {0} [built]
  [151] ./~/react/lib/toArray.js 2542 {0} [built]

ERROR in ./app/stores/auth_store.js
Module build failed: Error: Invalid mapping: {"generated":{"line":1,"column":4},"source":"/Users/koss/src/app-front/app/stores/auth_store.js","original":{"line":1,"column":-10433},"name":"Fluxxor$1335"}
    at SourceMapGenerator_validateMapping [as _validateMapping] (/Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/node_modules/source-map/lib/source-map/source-map-generator.js:272:15)
    at SourceMapGenerator_addMapping [as addMapping] (/Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/node_modules/source-map/lib/source-map/source-map-generator.js:102:12)
    at /Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/node_modules/source-map/lib/source-map/source-node.js:336:15
    at SourceNode_walk [as walk] (/Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/node_modules/source-map/lib/source-map/source-node.js:215:11)
    at SourceNode_walk [as walk] (/Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/node_modules/source-map/lib/source-map/source-node.js:211:15)
    at SourceNode_walk [as walk] (/Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/node_modules/source-map/lib/source-map/source-node.js:211:15)
    at SourceNode_walk [as walk] (/Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/node_modules/source-map/lib/source-map/source-node.js:211:15)
    at SourceNode_walk [as walk] (/Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/node_modules/source-map/lib/source-map/source-node.js:211:15)
    at SourceNode_toStringWithSourceMap [as toStringWithSourceMap] (/Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/node_modules/source-map/lib/source-map/source-node.js:327:10)
    at Object.generate (/Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/escodegen.js:2148:23)
 @ ./app/app.jsx 6:21-49

ERROR in ./app/stores/system_store.js
Module build failed: Error: Invalid mapping: {"generated":{"line":1,"column":4},"source":"/Users/koss/src/app-front/app/stores/system_store.js","original":{"line":1,"column":-10433},"name":"Fluxxor$1411"}
    at SourceMapGenerator_validateMapping [as _validateMapping] (/Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/node_modules/source-map/lib/source-map/source-map-generator.js:272:15)
    at SourceMapGenerator_addMapping [as addMapping] (/Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/node_modules/source-map/lib/source-map/source-map-generator.js:102:12)
    at /Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/node_modules/source-map/lib/source-map/source-node.js:336:15
    at SourceNode_walk [as walk] (/Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/node_modules/source-map/lib/source-map/source-node.js:215:11)
    at SourceNode_walk [as walk] (/Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/node_modules/source-map/lib/source-map/source-node.js:211:15)
    at SourceNode_walk [as walk] (/Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/node_modules/source-map/lib/source-map/source-node.js:211:15)
    at SourceNode_walk [as walk] (/Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/node_modules/source-map/lib/source-map/source-node.js:211:15)
    at SourceNode_walk [as walk] (/Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/node_modules/source-map/lib/source-map/source-node.js:211:15)
    at SourceNode_toStringWithSourceMap [as toStringWithSourceMap] (/Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/node_modules/source-map/lib/source-map/source-node.js:327:10)
    at Object.generate (/Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/escodegen.js:2148:23)
 @ ./app/app.jsx 8:23-53

ERROR in ./app/stores/user_store.js
Module build failed: Error: Invalid mapping: {"generated":{"line":1,"column":4},"source":"/Users/koss/src/app-front/app/stores/user_store.js","original":{"line":1,"column":-10433},"name":"Fluxxor$1430"}
    at SourceMapGenerator_validateMapping [as _validateMapping] (/Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/node_modules/source-map/lib/source-map/source-map-generator.js:272:15)
    at SourceMapGenerator_addMapping [as addMapping] (/Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/node_modules/source-map/lib/source-map/source-map-generator.js:102:12)
    at /Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/node_modules/source-map/lib/source-map/source-node.js:336:15
    at SourceNode_walk [as walk] (/Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/node_modules/source-map/lib/source-map/source-node.js:215:11)
    at SourceNode_walk [as walk] (/Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/node_modules/source-map/lib/source-map/source-node.js:211:15)
    at SourceNode_walk [as walk] (/Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/node_modules/source-map/lib/source-map/source-node.js:211:15)
    at SourceNode_walk [as walk] (/Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/node_modules/source-map/lib/source-map/source-node.js:211:15)
    at SourceNode_walk [as walk] (/Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/node_modules/source-map/lib/source-map/source-node.js:211:15)
    at SourceNode_toStringWithSourceMap [as toStringWithSourceMap] (/Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/node_modules/source-map/lib/source-map/source-node.js:327:10)
    at Object.generate (/Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/escodegen.js:2148:23)
 @ ./app/app.jsx 9:21-49

ERROR in ./app/stores/projects_store.js
Module build failed: Error: Invalid mapping: {"generated":{"line":1,"column":4},"source":"/Users/koss/src/app-front/app/stores/projects_store.js","original":{"line":1,"column":-10433},"name":"Fluxxor$1459"}
    at SourceMapGenerator_validateMapping [as _validateMapping] (/Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/node_modules/source-map/lib/source-map/source-map-generator.js:272:15)
    at SourceMapGenerator_addMapping [as addMapping] (/Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/node_modules/source-map/lib/source-map/source-map-generator.js:102:12)
    at /Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/node_modules/source-map/lib/source-map/source-node.js:336:15
    at SourceNode_walk [as walk] (/Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/node_modules/source-map/lib/source-map/source-node.js:215:11)
    at SourceNode_walk [as walk] (/Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/node_modules/source-map/lib/source-map/source-node.js:211:15)
    at SourceNode_walk [as walk] (/Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/node_modules/source-map/lib/source-map/source-node.js:211:15)
    at SourceNode_walk [as walk] (/Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/node_modules/source-map/lib/source-map/source-node.js:211:15)
    at SourceNode_walk [as walk] (/Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/node_modules/source-map/lib/source-map/source-node.js:211:15)
    at SourceNode_toStringWithSourceMap [as toStringWithSourceMap] (/Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/node_modules/source-map/lib/source-map/source-node.js:327:10)
    at Object.generate (/Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/escodegen.js:2148:23)
 @ ./app/app.jsx 10:25-57

ERROR in ./app/routes/router.jsx
Module build failed: Error: Invalid mapping: {"generated":{"line":1,"column":4},"source":"/Users/koss/src/app-front/app/routes/router.jsx","original":{"line":1,"column":-10433},"name":"React$1496"}
    at SourceMapGenerator_validateMapping [as _validateMapping] (/Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/node_modules/source-map/lib/source-map/source-map-generator.js:272:15)
    at SourceMapGenerator_addMapping [as addMapping] (/Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/node_modules/source-map/lib/source-map/source-map-generator.js:102:12)
    at /Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/node_modules/source-map/lib/source-map/source-node.js:336:15
    at SourceNode_walk [as walk] (/Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/node_modules/source-map/lib/source-map/source-node.js:215:11)
    at SourceNode_walk [as walk] (/Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/node_modules/source-map/lib/source-map/source-node.js:211:15)
    at SourceNode_walk [as walk] (/Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/node_modules/source-map/lib/source-map/source-node.js:211:15)
    at SourceNode_walk [as walk] (/Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/node_modules/source-map/lib/source-map/source-node.js:211:15)
    at SourceNode_walk [as walk] (/Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/node_modules/source-map/lib/source-map/source-node.js:211:15)
    at SourceNode_toStringWithSourceMap [as toStringWithSourceMap] (/Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/node_modules/source-map/lib/source-map/source-node.js:327:10)
    at Object.generate (/Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/escodegen.js:2148:23)
 @ ./app/app.jsx 11:18-46

ERROR in ./~/fluxxor/index.js
Module build failed: Error: Invalid mapping: {"generated":{"line":1,"column":4},"source":"/Users/koss/src/app-front/node_modules/fluxxor/index.js","original":{"line":1,"column":-10433},"name":"Dispatcher$1538"}
    at SourceMapGenerator_validateMapping [as _validateMapping] (/Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/node_modules/source-map/lib/source-map/source-map-generator.js:272:15)
    at SourceMapGenerator_addMapping [as addMapping] (/Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/node_modules/source-map/lib/source-map/source-map-generator.js:102:12)
    at /Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/node_modules/source-map/lib/source-map/source-node.js:336:15
    at SourceNode_walk [as walk] (/Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/node_modules/source-map/lib/source-map/source-node.js:215:11)
    at SourceNode_walk [as walk] (/Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/node_modules/source-map/lib/source-map/source-node.js:211:15)
    at SourceNode_walk [as walk] (/Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/node_modules/source-map/lib/source-map/source-node.js:211:15)
    at SourceNode_walk [as walk] (/Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/node_modules/source-map/lib/source-map/source-node.js:211:15)
    at SourceNode_walk [as walk] (/Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/node_modules/source-map/lib/source-map/source-node.js:211:15)
    at SourceNode_toStringWithSourceMap [as toStringWithSourceMap] (/Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/node_modules/source-map/lib/source-map/source-node.js:327:10)
    at Object.generate (/Users/koss/src/app-front/node_modules/sweet.js/node_modules/escodegen/escodegen.js:2148:23)
 @ ./app/app.jsx 4:19-37
webpack: bundle is now VALID.
^C~                                                                                                                                                                                                                                          
```
