### PR TITLE
pass through parameter readableNames to sweet.js compiler

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,8 @@ module.exports = function(source) {
     var result = sweet.compile(source, {
       modules: modules,
       sourceMap: true,
-      filename: fileRequest
+      filename: fileRequest,
+      readableNames: !!config.readableNames
     });
 
     loader.cacheable && loader.cacheable();


### PR DESCRIPTION
There's a readable names parameter that is part of the sweet.js API.  It'd be nice to pass through that parameter as a loader configuration.